### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.knights.json
+++ b/org.kde.knights.json
@@ -16,6 +16,7 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
+        "/share/carddecks",
         "/share/doc",
         "/share/gnuchess",
         "/share/info",


### PR DESCRIPTION
This PR removes the /share/carddecks folder, which is not required for this game.